### PR TITLE
Not including `requiredCapabilities` property in request content of New Session command when its value is `undef`

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,14 +22,13 @@ dependencies:
 test:
   override:
 
-#XXX
-#    - docker run --name firefoxdriver -d --net=host -t quay.io/wakaba/firefoxdriver:stable /fx:
-#        parallel: true
-#    - TEST_WD_URL=http://localhost:9516/wd/hub make test :
-#        timeout: 600
-#        parallel: true
-#    - docker kill firefoxdriver:
-#        parallel: true
+    - docker run --name firefoxdriver -d --net=host -t quay.io/wakaba/firefoxdriver:stable /fx:
+        parallel: true
+    - TEST_WD_URL=http://localhost:9516 make test :
+        timeout: 600
+        parallel: true
+    - docker kill firefoxdriver:
+        parallel: true
 
     - docker run --name chromedriver -d --net=host -t quay.io/wakaba/chromedriver:stable /cd:
         parallel: true

--- a/lib/Web/Driver/Client/Connection.pm
+++ b/lib/Web/Driver/Client/Connection.pm
@@ -52,7 +52,7 @@ sub new_session ($;%) {
   my ($self, %args) = @_;
   return $self->http_post (['session'], {
     desiredCapabilities => $args{desired} || {},
-    requiredCapabilities => $args{required},
+    ($args{required} ? (requiredCapabilities => $args{required}) : ()),
   })->then (sub {
     my $res = $_[0];
     die $res if $res->is_error;


### PR DESCRIPTION
## Background

The `requiredCapabilities` property in the request content of New Session command is optional.

* **Old** W3C WebDriver spec says “If *required capabilities* is not a JSON Object, set the value to an empty JSON Object.” ( See: https://github.com/w3c/webdriver/commit/d0ef240f535d00413403d4006f2b6dd7a3298eac )
* **Deprecated** Selenium WebDriver Wire protocol wiki page says “`requiredCapabilities` - `{object}` An object describing the session's required capabilities (Optional).” ( See: https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol )

## Problem on geckodriver

geckodriver 0.14.0 returns error response when `requiredCapabilities` has `null` value.

```
root@e476876d87e7:/app# WEBUA_DEBUG=2 TEST_WD_URL=http://localhost:9516 ./local/bin/perl t/basic.t
1..1
5.1: Web::Transport::ConnectionClient: New connection Sun Mar  5 13:48:27 2017
(omitted)
5.1.1.1: S: POST /session HTTP/1.1\x0D
5.1.1.1: S: Host: localhost:9516\x0D
(omitted)
5.1.1.1: S: \x0D
5.1.1.1: S: {"desiredCapabilities":{"browserName":"firefox"},"requiredCapabilities":null}
5.1.1.1: requestsent Sun Mar  5 13:48:27 2017
5.1.1.1: headers Sun Mar  5 13:48:27 2017
5.1.1.1: R: HTTP/1.1 400 Bad Request
(omitted)
5.1.1.1: R: {"error":"invalid argument","message":"'requiredCapabilities' parameter is not an object","stacktrace":"stack backtrace:\x5Cn   0:           0x4e0eed - backtrace::backtrace::trace::had1fe133e10f4f84\x5Cn   1:           0x4e13b2 - backtrace::capture::Backtrace::new::hea6d366cd875d5b7\x5Cn   2:           0x4c5565 - <webdriver::command::NewSessionParameters as webdriver::command::Parameters>::from_json::h4aab863631ed3ac5\x5Cn   3:           0x41ec5d - <webdriver::command::WebDriverMessage<U>>::from_http::h8f0a33d31c1f6bec\x5Cn   4:           0x42f4d9 - <webdriver::server::HttpHandler<U> as hyper::server::Handler>::handle::hb3afae7e1d490843\x5Cn   5:           0x40d136 - std::panicking::try::do_call::h59d87e6a50feaed1\x5Cn   6:           0x5801da - panic_unwind::__rust_maybe_catch_panic\x5Cn                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-musl-linux/build/obj/../src/libpanic_unwind/lib.rs:97\x5Cn   7:           0x41ce79 - <F as alloc::boxed::FnBox<A>>::call_box::h5a9c0b5f3944e784\x5Cn   8:           0x576944 - alloc::boxed::{{impl}}::call_once<(),()>\x5Cn                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-musl-linux/build/obj/../src/liballoc/boxed.rs:605\x5Cn                         - std::sys_common::thread::start_thread\x5Cn                        at
5.1.1.1: data Sun Mar  5 13:48:27 2017
5.1.1.1: R:  /buildslave/rust-buildbot/slave/stable-dist-rustc-musl-linux/build/obj/../src/libstd/sys_common/thread.rs:21\x5Cn                         - std::sys::imp::thread::{{impl}}::new::thread_start\x5Cn                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-musl-linux/build/obj/../src/libstd/sys/unix/thread.rs:84"}
(omitted)
```

I think this behavior of geckodriver is not good, but I don't know whether the behavior is wrong or not, because there is no **living** specification about `requiredCapabilities` property. (The `requiredCapabilities` property is not used in living document.)

## What this pull request do

To let perl-web-driver-client work along with geckodriver, this pull request modifies the request content of New Session command.

The `requiredCapabilities` property will not be included in request content of New Session command when its value is `undef`.

The test process along with docker-firefoxdriver on CircleCI is also restored.