### PR TITLE
Use Find Element command instead of Execute Script command in t/session-http.t

### DIFF
--- a/t/session-http.t
+++ b/t/session-http.t
@@ -28,18 +28,27 @@ test {
         test {
           isa_ok $res, 'Web::Driver::Client::Response';
         } $c;
-        return $session->http_post (['execute'], {
-          script => q{
-            return document.body.textContent;
-          },
-          args => [],
+        return $session->http_post (['element'], {
+          using => 'xpath',
+          value => '//body',
         });
       })->then (sub {
         my $res = $_[0];
         test {
           isa_ok $res, 'Web::Driver::Client::Response';
+          ok !$res->is_error, 'Not error response';
           my $value = $res->json->{value};
-          is $value, $body;
+
+          # The web element identifier is a constant with the string "element-6066-11e4-a52e-4f735466cecf".
+          # See : https://www.w3.org/TR/webdriver/#dfn-web-element-identifier
+          my $web_element_identifier = 'element-6066-11e4-a52e-4f735466cecf';
+          # In Json Wire Protocol, "ELEMENT" is used.
+          # See : https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#webelement-json-object
+          my $web_element_identifier_for_jwp = 'ELEMENT';
+
+          ok exists($value->{$web_element_identifier}) || exists($value->{$web_element_identifier_for_jwp}),
+              'Response of `http_post` method contains a return value of command. ' .
+              '(In this case that is JSON serialization of an element.)';
         } $c;
         return $session->http_get (['url']);
       })->then (sub {
@@ -50,13 +59,14 @@ test {
       });
     });
   });
-} n => 4, name => 'http_* API';
+} n => 5, name => 'http_* API';
 
 run_tests;
 
 =head1 LICENSE
 
 Copyright 2016-2017 Wakaba <wakaba@suikawiki.org>.
+Copyright 2018 OND Inc. <https://ond-inc.com/>.
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself.

--- a/t/session-http.t
+++ b/t/session-http.t
@@ -40,7 +40,7 @@ test {
           my $value = $res->json->{value};
 
           # The web element identifier is a constant with the string "element-6066-11e4-a52e-4f735466cecf".
-          # See : https://www.w3.org/TR/webdriver/#dfn-web-element-identifier
+          # See : https://w3c.github.io/webdriver/webdriver-spec.html#dfn-web-element-identifier
           my $web_element_identifier = 'element-6066-11e4-a52e-4f735466cecf';
           # In Json Wire Protocol, "ELEMENT" is used.
           # See : https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#webelement-json-object


### PR DESCRIPTION
Because `POST /session/{session_id}/execute` is removed on geckodriver 0.16.0.

* Find Element command : https://www.w3.org/TR/webdriver/#dfn-find-element